### PR TITLE
feat: add Playwright E2E testing framework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+TENANT=carpentersunion
+BASE_HOST=localhost
+PROTOCOL=http
+OFFICE_ADMIN_EMAIL=office.admin@get-code.net
+OFFICE_ADMIN_PASSWORD=

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,36 @@
+name: e2e
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [chromium-desktop, chromium-ipad]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npx playwright install --with-deps chromium
+      - name: Run smoke on PR
+        if: ${{ github.event_name == 'pull_request' }}
+        run: npx playwright test --project=${{ matrix.project }} --grep "@smoke"
+      - name: Run full suite
+        if: ${{ github.event_name != 'pull_request' }}
+        run: npx playwright test --project=${{ matrix.project }}
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-${{ matrix.project }}
+          path: reports

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+reports
+.env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing Guide
+
+## Code Review Checklist
+- [ ] Tests include Jira key in title (e.g. `ERP-123`).
+- [ ] Tags follow schema `@p0/@p1`, `@smoke`, `@regression`, `@tenant:*`, `@role:*`, `@module:*`.
+- [ ] No hard waits; use `expect` with timeouts.
+- [ ] Helpers and configs are documented.
+- [ ] Secrets pulled from environment variables.
+- [ ] New tests clean up data and are idempotent.
+- [ ] Screenshots, traces, and videos saved to `reports/artifacts`.

--- a/README.md
+++ b/README.md
@@ -1,214 +1,37 @@
-# playwright
-You are a senior test architect. Produce a complete, production-ready E2E testing framework for the ERP described below. Follow the specifications and output format exactly.
-Objective
-Design and generate an end-to-end testing framework that:
-runs headless and headed locally and in CI
-
-
-is deterministic and flake-resistant
-
-
-supports multi-tenant ERP scenarios and role-based auth
-
-
-integrates with CI/CD and environments
-
-
-provides artifacts, dashboards, and traceability
-
-
-ERP Context
-Domain: US Labor Unions
-
-
-Tenancy model: single-tenant  tenant routing: subdomain
-
-
-Frontend: Vue 3 + yarn, vite 
-
-
-Backend: Laravel 12  Node  API style: REST
-
-
-DB: MariaDB}
-
-
-AuthN/Z:  cartalyst sentinel, roles: Office Admin
-
-
-Critical flows: 
-For each module: by office admin, open each page and check the response. ensure it doeesnt fails.
-
-
-Non-functional
-Browsers: Chromium
-
-
-Parallelism: 1
-
-
-Performance budgets: use benchmarks
-
-
-Security checks: use benchmarks
-
-
-Accessibility: use benchmarks
-
-
-
-Tooling and Language
-Primary test runner: Playwright 
-Language: TypeScript
-
-
-API tests: | Playwright request
-
-
-
-CI/CD
-CI: GitHub Actions
-
-
-Triggers: mannaully
-
-
-Matrix: Chrome on Desctop, Chrome on iPad
-
-
-Artifacts: videos, traces, screenshots, HTML report
-
-
-Gates: fail build on p0 tests; quarantine tag allowed but tracked
-
-
-Reporting and Traceability
-Test management mapping: Jira keys like ERP-123
-Tag schema: @p0/@p1, @smoke, @regression, @tenant:carpentersunion, @role:office_admin, @module:members
-
-
-Dashboard: Playwright HTML 
-
-
-Environments
-Local: localhost
-
-
-Output Requirements
-Repository structure tree
-
-
-Package manifest(s) with pinned versions
-
-
-Config files with comments
-
-
-Reusable helpers: auth, tenant switch, data seed, API client
-
-
-Test data strategy and seed scripts
-
-
-Example specs for each core flow (at least 6)
-
-
-CI pipeline YAML
-
-
-Reporting config and sample output paths
-
-
-README.md with setup, run commands, troubleshooting, and flake policy
-
-
-Contribution guide with code review checklist
-
-
-Constraints and Guardrails
-Determinism: no hard sleeps; use robust waits and fixtures
-
-
-Network: block third-party unless whitelisted
-
-
-Test IDs: prefer data-testid attributes; avoid brittle selectors
-
-
-Secrets: pull from env; never hardcode
-
-
-Isolation: per-test tenant or namespace; clean up after each test
-
-
-Flake policy: retry once on known-flaky tags only; otherwise fail
-
-
-Performance step: capture timings; assert budgets
-
-
-Accessibility step: run axe; fail on severity ≥ {{level}}
-
-
-Idempotency: specs safe on re-run
-
-
-Documentation: every helper and config commented
-
-
-Acceptance Criteria
-npm run test:e2e runs locally headless
-
-
-npm run test:debug runs headed with trace on
-
-
-CI pipeline executes smoke on PR, full on main and nightly
-
-
-Artifacts uploaded; failing tests show trace and screenshot
-
-
-README instructions work from clean clone in <15 minutes
-
-
-Example Inputs to Embed
-Default tenant: carpentersunion
-
-
-Default users: office.admin@get-code.net password in .env
-
-
-Deliverable Format
-Return only the following blocks, in order:
-Create repo structure
-create  all needed files 
-add all needed dependencies 
-create test congigs 
-ctete test structure
-create sample tests I can expand later 
-
-Few-Shot Style Guide
-Use TypeScript types for fixtures and helpers.
-Provide real commands and scripts:
-npm run test:e2e, npm run test:headed, npm run test:trace, npm run test:report,
-Include an auth helper that supports:
-programmatic login via API
-
-
-Include a tenant helper that supports:
-subdomain switch or multi-tenant
-Include tagging:
-test.describe.configure({ mode: 'parallel' });
-test('p0 smoke: member lifecycle @p0 @smoke @module:members @tenant:default @role:admin', ...)
-Add a flake-resistant wait pattern example:
-await expect(locator).toHaveText(/Created/i, { timeout: 15000 });
-
-
-If Information Is Missing
-Make reasonable assumptions consistent with ERP systems.
-Document assumptions at top of README under “Assumptions.”
-Do not ask questions. Proceed and generate.
-
-
-
+# ERP E2E Test Framework
+
+## Assumptions
+- ERP exposes tenant via subdomain (e.g. `carpentersunion.localhost`).
+- Programmatic login available at `/api/login` returning `{ token }`.
+- `OFFICE_ADMIN_EMAIL` and `OFFICE_ADMIN_PASSWORD` stored in `.env`.
+- MariaDB state can be seeded via REST API.
+
+## Setup
+```bash
+# install dependencies
+npm install
+# copy environment
+cp .env.example .env && edit values
+# install browsers
+npx playwright install --with-deps chromium
+```
+
+## Commands
+- `npm run test:e2e` – run headless suite.
+- `npm run test:debug` – run headed with Playwright inspector.
+- `npm run test:trace` – run headed with trace capture.
+- `npm run test:report` – open last HTML report.
+- `npm run seed` – seed baseline data.
+
+## Flake Policy
+- Tests tagged `@quarantine` retry once via `test.describe.configure({ retries: 1 })`.
+- All other tests fail on first error.
+
+## Troubleshooting
+- Ensure API server is running and reachable via tenant subdomain.
+- Delete `reports/` if Playwright cannot write artifacts.
+- Run with `DEBUG=pw:api` for verbose logs.
+
+## Artifact Paths
+- HTML report: `reports/html`.
+- Traces, videos, screenshots: `reports/artifacts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,352 @@
+{
+  "name": "erp-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "erp-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@axe-core/playwright": "4.10.2",
+        "@playwright/test": "1.44.0",
+        "dotenv": "16.4.1",
+        "ts-node": "10.9.2",
+        "typescript": "5.4.5"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
+      "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
+      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.44.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
+      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.44.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "erp-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:debug": "PWDEBUG=1 playwright test --headed",
+    "test:trace": "playwright test --trace on --headed",
+    "test:report": "playwright show-report",
+    "seed": "ts-node scripts/seed.ts"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "4.10.2",
+    "@playwright/test": "1.44.0",
+    "dotenv": "16.4.1",
+    "ts-node": "10.9.2",
+    "typescript": "5.4.5"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+import 'dotenv/config';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  /* Ensure no accidental only's land in CI */
+  forbidOnly: !!process.env.CI,
+  /* Retry policy handled via @quarantine tag in specs */
+  retries: 0,
+  /* Run tests sequentially for determinism */
+  workers: 1,
+  timeout: 30_000,
+  expect: { timeout: 15_000 },
+  /* Artifacts */
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'reports/html', open: 'never' }]
+  ],
+  outputDir: 'reports/artifacts',
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost',
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure'
+  },
+  /* Browser matrix */
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium-ipad',
+      use: { ...devices['iPad (gen 7) landscape'] },
+    }
+  ]
+});

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,8 @@
+import 'dotenv/config';
+import { seedMember } from '../src/helpers/seed';
+
+(async () => {
+  const tenant = process.env.TENANT || 'carpentersunion';
+  await seedMember(tenant, { name: 'Test Member' });
+  console.log(`Seed data created for ${tenant}`);
+})();

--- a/src/helpers/apiClient.ts
+++ b/src/helpers/apiClient.ts
@@ -1,0 +1,15 @@
+import { request, APIRequestContext } from '@playwright/test';
+import { getTenantUrl } from './tenant';
+
+/**
+ * Create an API client bound to a specific tenant.
+ */
+export async function createApiClient(tenant: string): Promise<APIRequestContext> {
+  const baseURL = getTenantUrl(tenant);
+  return await request.newContext({
+    baseURL,
+    extraHTTPHeaders: {
+      'Accept': 'application/json'
+    }
+  });
+}

--- a/src/helpers/auth.ts
+++ b/src/helpers/auth.ts
@@ -1,0 +1,29 @@
+import { APIRequestContext, Page } from '@playwright/test';
+import { getTenantUrl } from './tenant';
+
+export interface LoginOptions {
+  request: APIRequestContext;
+  page: Page;
+  tenant: string;
+  email?: string;
+  password?: string;
+}
+
+/**
+ * Programmatic login to avoid UI flakiness.
+ */
+export async function loginAs({ request, page, tenant, email = process.env.OFFICE_ADMIN_EMAIL!, password = process.env.OFFICE_ADMIN_PASSWORD! }: LoginOptions): Promise<void> {
+  const base = getTenantUrl(tenant);
+  const resp = await request.post(`${base}/api/login`, {
+    data: { email, password }
+  });
+  if (!resp.ok()) {
+    throw new Error(`Login failed: ${resp.status()} ${resp.statusText()}`);
+  }
+  const { token } = await resp.json();
+  // Persist token for app usage
+  await page.addInitScript(([t]) => {
+    window.localStorage.setItem('auth_token', t);
+  }, token);
+  await page.goto(base);
+}

--- a/src/helpers/seed.ts
+++ b/src/helpers/seed.ts
@@ -1,0 +1,7 @@
+import { createApiClient } from './apiClient';
+
+export async function seedMember(tenant: string, data: { name: string }): Promise<void> {
+  const client = await createApiClient(tenant);
+  await client.post('/api/members', { data });
+  await client.dispose();
+}

--- a/src/helpers/tenant.ts
+++ b/src/helpers/tenant.ts
@@ -1,0 +1,9 @@
+/**
+ * Build a tenant-scoped base URL using subdomain routing.
+ */
+export function getTenantUrl(tenant: string, path = ''): string {
+  const host = process.env.BASE_HOST || 'localhost';
+  const protocol = process.env.PROTOCOL || 'http';
+  const base = `${protocol}://${tenant}.${host}`;
+  return `${base}${path}`;
+}

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '../fixtures/base';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('Dashboard module', () => {
+  test.describe.configure({ mode: 'parallel' });
+
+  test('ERP-106 open dashboard page @p0 @smoke @module:dashboard @tenant:carpentersunion @role:office_admin', async ({ authenticatedPage }) => {
+    const start = Date.now();
+    await authenticatedPage.goto('/dashboard');
+    await expect(authenticatedPage.getByTestId('dashboard-page')).toBeVisible();
+    await expect(authenticatedPage.locator('h1')).toHaveText(/Dashboard/i, { timeout: 15000 });
+    const axe = await new AxeBuilder({ page: authenticatedPage }).analyze();
+    expect(axe.violations).toEqual([]);
+    const duration = Date.now() - start;
+    expect(duration).toBeLessThan(2000);
+  });
+});

--- a/tests/e2e/meetings.spec.ts
+++ b/tests/e2e/meetings.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '../fixtures/base';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('Meetings module', () => {
+  test.describe.configure({ mode: 'parallel' });
+
+  test('ERP-102 open meetings page @p1 @regression @module:meetings @tenant:carpentersunion @role:office_admin', async ({ authenticatedPage }) => {
+    const start = Date.now();
+    await authenticatedPage.goto('/meetings');
+    await expect(authenticatedPage.getByTestId('meetings-page')).toBeVisible();
+    const axe = await new AxeBuilder({ page: authenticatedPage }).analyze();
+    expect(axe.violations).toEqual([]);
+    const duration = Date.now() - start;
+    expect(duration).toBeLessThan(2000);
+  });
+});

--- a/tests/e2e/members.spec.ts
+++ b/tests/e2e/members.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '../fixtures/base';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('Members module', () => {
+  test.describe.configure({ mode: 'parallel' });
+
+  test('ERP-101 open members page @p0 @smoke @module:members @tenant:carpentersunion @role:office_admin', async ({ authenticatedPage }) => {
+    const start = Date.now();
+    await authenticatedPage.goto('/members');
+    await expect(authenticatedPage.getByTestId('members-page')).toBeVisible();
+    const axe = await new AxeBuilder({ page: authenticatedPage }).analyze();
+    expect(axe.violations).toEqual([]);
+    const duration = Date.now() - start;
+    expect(duration).toBeLessThan(2000);
+  });
+});

--- a/tests/e2e/payments.spec.ts
+++ b/tests/e2e/payments.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '../fixtures/base';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('Payments module', () => {
+  test.describe.configure({ mode: 'parallel' });
+
+  test('ERP-103 open payments page @p0 @smoke @module:payments @tenant:carpentersunion @role:office_admin', async ({ authenticatedPage }) => {
+    const start = Date.now();
+    await authenticatedPage.goto('/payments');
+    await expect(authenticatedPage.getByTestId('payments-page')).toBeVisible();
+    const axe = await new AxeBuilder({ page: authenticatedPage }).analyze();
+    expect(axe.violations).toEqual([]);
+    const duration = Date.now() - start;
+    expect(duration).toBeLessThan(2000);
+  });
+});

--- a/tests/e2e/reports.spec.ts
+++ b/tests/e2e/reports.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '../fixtures/base';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('Reports module', () => {
+  test.describe.configure({ mode: 'parallel', retries: 1 });
+
+  test('ERP-104 open reports page @p1 @regression @module:reports @tenant:carpentersunion @role:office_admin @quarantine', async ({ authenticatedPage }) => {
+    const start = Date.now();
+    await authenticatedPage.goto('/reports');
+    await expect(authenticatedPage.getByTestId('reports-page')).toBeVisible();
+    const axe = await new AxeBuilder({ page: authenticatedPage }).analyze();
+    expect(axe.violations).toEqual([]);
+    const duration = Date.now() - start;
+    expect(duration).toBeLessThan(2000);
+  });
+});

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '../fixtures/base';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('Settings module', () => {
+  test.describe.configure({ mode: 'parallel' });
+
+  test('ERP-105 open settings page @p1 @regression @module:settings @tenant:carpentersunion @role:office_admin', async ({ authenticatedPage }) => {
+    const start = Date.now();
+    await authenticatedPage.goto('/settings');
+    await expect(authenticatedPage.getByTestId('settings-page')).toBeVisible();
+    const axe = await new AxeBuilder({ page: authenticatedPage }).analyze();
+    expect(axe.violations).toEqual([]);
+    const duration = Date.now() - start;
+    expect(duration).toBeLessThan(2000);
+  });
+});

--- a/tests/fixtures/base.ts
+++ b/tests/fixtures/base.ts
@@ -1,0 +1,28 @@
+import { test as base, expect } from '@playwright/test';
+import { loginAs } from '../../src/helpers/auth';
+
+type Fixtures = {
+  authenticatedPage: import('@playwright/test').Page;
+};
+
+export const test = base.extend<Fixtures>({
+  page: async ({ page }, use) => {
+    // Block third-party requests to keep tests deterministic
+    await page.route('**/*', route => {
+      const url = new URL(route.request().url());
+      if (url.hostname.endsWith('localhost')) {
+        route.continue();
+      } else {
+        route.abort();
+      }
+    });
+    await use(page);
+  },
+  authenticatedPage: async ({ page, request }, use) => {
+    const tenant = process.env.TENANT || 'carpentersunion';
+    await loginAs({ request, page, tenant });
+    await use(page);
+  }
+});
+
+export { expect };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "lib": ["ESNext", "DOM"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "tests", "scripts", "playwright.config.ts"]
+}


### PR DESCRIPTION
## Summary
- set up Playwright TypeScript test framework with multi-tenant helpers
- add sample smoke & regression specs for core modules
- configure GitHub Actions matrix and artifact uploads

## Testing
- `npm run test:e2e` *(fails: no application available)*

------
https://chatgpt.com/codex/tasks/task_e_68bc480caab4832e8c23815d39135fc0